### PR TITLE
Fixes height of homepage cards, adjusts icons

### DIFF
--- a/packages/web/src/HomePage.tsx
+++ b/packages/web/src/HomePage.tsx
@@ -47,7 +47,8 @@ import {
 } from "@patternfly/react-core";
 import { Link } from "react-router-dom";
 import { Pf4Label } from "./Pf4Label";
-import { DesktopIcon, CodeIcon, FileImageIcon } from "@patternfly/react-icons";
+import { DesktopIcon, CodeIcon, FileImageIcon, RepositoryIcon } from "@patternfly/react-icons";
+
 
 interface Space {
   name: string;
@@ -94,7 +95,6 @@ export function Homepage() {
       </PageSection>
       <PageSection variant="dark">
         <Gallery gutter="lg">
-          <GalleryItem>
             <Card>
               <CardHeader>
                 <Title size="2xl">Desktop</Title>
@@ -124,8 +124,6 @@ export function Homepage() {
                 </Split>
               </CardFooter>
             </Card>
-          </GalleryItem>
-          <GalleryItem>
             <Card>
               <CardHeader>
                 <Title size="2xl">Web</Title>
@@ -154,8 +152,6 @@ export function Homepage() {
                 </Split>
               </CardFooter>
             </Card>
-          </GalleryItem>
-          <GalleryItem>
             <Card>
               <CardHeader>
                 <Title size="2xl">Browser extensions</Title>
@@ -169,14 +165,13 @@ export function Homepage() {
                 </TextContent>
                 <List>
                   <ListItem>Community focused</ListItem>
-                  <ListItem>Integrate diretly into source code host (GitHub)</ListItem>
+                  <ListItem>Integrate directly into source code host (GitHub)</ListItem>
                 </List>
               </CardBody>
               <CardFooter>
                 <Split>
                   <SplitItem isMain={true}>
-                    <FileImageIcon size="lg" />
-                    <CodeIcon size="lg" />
+                    <RepositoryIcon size="lg" />
                   </SplitItem>
                   <SplitItem isMain={false}>
                     <Button variant="primary">Get browser extension</Button>
@@ -184,8 +179,6 @@ export function Homepage() {
                 </Split>
               </CardFooter>
             </Card>
-          </GalleryItem>
-          <GalleryItem>
             <Card>
               <CardHeader>
                 <Title size="2xl">IDE extensions</Title>
@@ -207,7 +200,6 @@ export function Homepage() {
                 <Split>
                   <SplitItem isMain={true}>
                     <FileImageIcon size="lg" />
-                    <CodeIcon size="lg" />
                   </SplitItem>
                   <SplitItem isMain={false}>
                     <Button variant="primary">Get IDE extension</Button>
@@ -215,7 +207,6 @@ export function Homepage() {
                 </Split>
               </CardFooter>
             </Card>
-          </GalleryItem>
         </Gallery>
       </PageSection>
     </>

--- a/packages/web/src/Main.tsx
+++ b/packages/web/src/Main.tsx
@@ -27,7 +27,7 @@ import { Editor } from "./Editor";
 import { AppContext } from "./AppContext";
 import { Import } from "./Import";
 import { Avatar, BackgroundImage, BackgroundImageSrc, Brand, Page, PageHeader } from "@patternfly/react-core";
-import { Homepage } from "./homepage";
+import { Homepage } from "./HomePage";
 
 const bgImages = {
   [BackgroundImageSrc.lg]: "/assets/images/pfbg_1200.jpg",

--- a/packages/web/static/index.html
+++ b/packages/web/static/index.html
@@ -27,6 +27,12 @@
 </head>
 <body>
 <div id="app" style="height: 100vh;"></div>
+    <style>
+      /* make the  */
+      .pf-l-gallery {
+        --pf-l-gallery--GridTemplateColumns: repeat(auto-fill,minmax(300px,1fr));
+      }
+    </style>
 <script src="/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The homepage cards should be in a grid but there is a PF4 React TS bug preventing it at the moment because not all the props were implemented. I put in an issue for it.